### PR TITLE
Display services correctly on the dashboard on server reboot

### DIFF
--- a/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
+++ b/app/controllers/OPNsense/Base/ApiMutableModelControllerBase.php
@@ -84,7 +84,7 @@ abstract class ApiMutableModelControllerBase extends ApiControllerBase
      * @param $uuid string uuid to check
      * @throws UserException containing additional information
      */
-    private function checkAndThrowSafeDelete($uuid)
+    protected function checkAndThrowSafeDelete($uuid)
     {
         if (static::$internalModelUseSafeDelete) {
             $configObj = Config::getInstance()->object();

--- a/opncell/src/etc/rc.d/epcamfd
+++ b/opncell/src/etc/rc.d/epcamfd
@@ -16,19 +16,14 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epcamfd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-required_files="${epc_config}"
-
 
 epcamfd_start(){
         echo "Starting open5gs-${service_name} daemon"
         sleep 4
         mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcamfd.pid"
-        cd /tmp || exit 1
+        pidfile="/var/run/epc/epcamfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name};then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcausfd
+++ b/opncell/src/etc/rc.d/epcausfd
@@ -17,17 +17,13 @@ command_args="-D > /dev/null 2>&1"
 load_rc_config ${name}
 : "${epcausfd_enable:="NO"}"
 
-required_files="${epc_config}"
-
-
 epcausfd_start(){
         echo "Starting open5gs-${service_name} daemon"
        
         mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcausfd.pid"
-        cd /tmp || exit 1
+        pidfile="/var/run/epc/epcausfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcbsfd
+++ b/opncell/src/etc/rc.d/epcbsfd
@@ -16,17 +16,13 @@ command_args="-D > /dev/null 2>&1"
 load_rc_config ${name}
 : "${epcbsfd_enable:="NO"}"
 
-required_files="${epc_config}"
-
-
 epcbsfd_start(){
         echo "Starting open5gs-${service_name} daemon"
        
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcbsfd.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcbsfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epchssd
+++ b/opncell/src/etc/rc.d/epchssd
@@ -16,19 +16,14 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epchssd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-required_files="${epc_config}"
-
 
 epchssd_start(){
     	echo "Starting open5gs-${service_name} daemon"
         sleep 4        
-#	mkdir -p /var/run/epc
-	pfile="/var/run/epc/epchssd.pid"
-	cd /tmp || exit 1
+	mkdir -p /var/run/epc
+	pidfile="/var/run/epc/epchssd.pid"
 
-	if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
     		echo "Started"
 	else
     		echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcmmed
+++ b/opncell/src/etc/rc.d/epcmmed
@@ -13,22 +13,20 @@ rcvar=${name}_enable
 command="/usr/ports/open5gs/install/bin/open5gs-${service_name}"
 start_cmd="${name}_start"
 command_args="-D > /dev/null 2>&1"
+#mkdir -p /var/run/epc
+#pidfile="/var/run/epc/${name}.pid"
 
 load_rc_config ${name}
 : "${epcmmed_enable:="NO"}"
-: "${epcmmed_config="/usr/local/etc/epc/epcmmed.conf"}"
-
-required_files="${epc_config}"
-
 
 epcmmed_start(){
     echo "Starting open5gs-${service_name} daemon"
 
 mkdir -p /var/run/epc
-pfile="/var/run/epc/epcmmed.pid"
-cd /tmp || exit 1
-if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
-    echo "Started"
+pidfile="/var/run/epc/epcmmed.pid"
+
+if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
+ echo "Started"
 else
     echo "Failed to start"
 fi

--- a/opncell/src/etc/rc.d/epcnrfd
+++ b/opncell/src/etc/rc.d/epcnrfd
@@ -17,17 +17,13 @@ command_args="-D > /dev/null 2>&1"
 load_rc_config ${name}
 : "${epcnrfd_enable:="NO"}"
 
-required_files="${epc_config}"
-
-
 epcnrfd_start(){
         echo "Starting open5gs-${service_name} daemon"
         
-#        mkdir  /var/run/epc
-        pfile="/var/run/epc/epcnrfd.pid"
-        cd /tmp || exit 1
+        mkdir  /var/run/epc
+        pidfile="/var/run/epc/epcnrfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcnssfd
+++ b/opncell/src/etc/rc.d/epcnssfd
@@ -18,12 +18,10 @@ load_rc_config ${name}
 
 epcnssfd_start(){
         echo "Starting open5gs-${service_name} daemon"
-        
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcnssfd.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcnssfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcpcfd
+++ b/opncell/src/etc/rc.d/epcpcfd
@@ -21,10 +21,9 @@ epcpcfd_start(){
         echo "Starting open5gs-${service_name} daemon"
         
         mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcpcfd.pid"
-        cd /tmp || exit 1
+        pidfile="/var/run/epc/epcpcfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcpcrfd
+++ b/opncell/src/etc/rc.d/epcpcrfd
@@ -21,10 +21,9 @@ epcpcrfd_start(){
         echo "Starting open5gs-${service_name} daemon"
         
         mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcpcrfd.pid"
-        cd /tmp || exit 1
+        pidfile="/var/run/epc/epcpcrfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcscpd
+++ b/opncell/src/etc/rc.d/epcscpd
@@ -22,12 +22,11 @@ load_rc_config ${name}
 
 epcscpd_start(){
         echo "Starting open5gs-${service_name} daemon"
-       # chmod +x /tmp/startmmed.sh
-        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcscpd.pid"
-        cd /tmp || exit 1
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcscpd.pid"
+
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcsgwcd
+++ b/opncell/src/etc/rc.d/epcsgwcd
@@ -22,12 +22,11 @@ load_rc_config ${name}
 
 epcsgwcd_start(){
         echo "Starting open5gs-${service_name} daemon"
-        #chmod +x /tmp/startmmed.sh
-        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcsgwcd.pid"
-        cd /tmp || exit 1
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcsgwcd.pid"
+
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcsgwud
+++ b/opncell/src/etc/rc.d/epcsgwud
@@ -15,19 +15,13 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epcsgwud_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-#required_files="${epc_config}"
-
 
 epcsgwud_start(){
         echo "Starting open5gs-${service_name} daemon"
-        #chmod +x /tmp/startmmed.sh
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcsgwud.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcsgwud.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcsmfd
+++ b/opncell/src/etc/rc.d/epcsmfd
@@ -16,19 +16,13 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epcsmfd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-#required_files="${epc_config}"
-
 
 epcsmfd_start(){
         echo "Starting open5gs-${service_name} daemon"
-#        chmod +x /tmp/startmmed.sh
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcsmfd.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcsmfd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcudmd
+++ b/opncell/src/etc/rc.d/epcudmd
@@ -14,20 +14,14 @@ start_cmd="${name}_start"
 command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
-: "${epcudmd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-#required_files="${epc_config}"
 
 
 epcudmd_start(){
         echo "Starting open5gs-${service_name} daemon"
-#        chmod +x /tmp/startmmed.sh
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcudmd.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcudmd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcudrd
+++ b/opncell/src/etc/rc.d/epcudrd
@@ -15,19 +15,13 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epcudrd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-#required_files="${epc_config}"
-
 
 epcudrd_start(){
         echo "Starting open5gs-${service_name} daemon"
-#        chmod +x /tmp/startmmed.sh
-#        mkdir -p /var/run/epc
-        pfile="/var/run/epc/epcudrd.pid"
-        cd /tmp || exit 1
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcudrd.pid"
 
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
         else
                 echo "Failed to start"

--- a/opncell/src/etc/rc.d/epcupfd
+++ b/opncell/src/etc/rc.d/epcupfd
@@ -17,21 +17,17 @@ command_args="-D > /dev/null 2>&1"
 
 load_rc_config ${name}
 : "${epcupfd_enable:="NO"}"
-#: "${epc_config="/usr/local/etc/epc/epc.conf"}"
-
-#required_files="${epc_config}"
-
 
 epcupfd_start(){
         echo "Starting open5gs-${service_name} daemon"
-        pfile="/var/run/epc/epcupfd.pid"
-        cd /tmp || exit 1
-        
+        mkdir -p /var/run/epc
+        pidfile="/var/run/epc/epcupfd.pid"
+
         if ifconfig | grep -q epc0; then
            ifconfig epc0 name tun0 > /dev/null 2>&1
         fi
         
-        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pfile}; then
+        if /usr/local/etc/rc.d/startmmed.sh ${command} ${pidfile} ${service_name}; then
                 echo "Started"
                 sleep 10   #Wait for daemon to initialize before renaming tun0 
         else

--- a/opncell/src/etc/rc.d/startmmed.sh
+++ b/opncell/src/etc/rc.d/startmmed.sh
@@ -2,7 +2,8 @@
 
 command="$1"
 PIDFILE="$2"
-
+service_name="$3"
 "${command}" -D > /dev/null 2>&1
+pgrep open5gs-"${service_name}" > "${PIDFILE}"
 
-ps aux | grep ${command}  | awk '$8 == "Is" || $8 == "Ss" || $8 == "Rs" {print $2}' > ${PIDFILE} 
+#ps aux | grep ${command}  | awk '$8 == "Is" || $8 == "Ss" || $8 == "Rs" {print $2}' > ${PIDFILE}

--- a/opncell/src/opnsense/mvc/app/models/OPNsense/OPNCore/Profile.xml
+++ b/opncell/src/opnsense/mvc/app/models/OPNsense/OPNCore/Profile.xml
@@ -27,7 +27,7 @@
                 </ul>
                 <QoS type="IntegerField">
                     <Required>Y</Required>
-                    <default>15</default>
+                    <default>9</default>
                     <ValidationMessage>Should be a character</ValidationMessage>
                 </QoS>
                 <arp_priority type="IntegerField">
@@ -40,7 +40,7 @@
 
                 <arp_capability type="OptionField">
                     <Required>Y</Required>
-                    <default>disabled</default>
+                    <default>enabled</default>
                     <OptionValues>
                         <enabled>enabled</enabled>
                         <disabled>disabled</disabled>

--- a/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py
@@ -1,0 +1,49 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 0:
+    def fetch():
+        result = "Failed"
+        os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+        os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+        # print(os.environ)
+
+        script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+        imsi = []
+        x = sys.argv[1]
+        y = x.replace('[', "")
+        t = y.replace(']', '')
+        json_data = json.loads(t)
+        #json_data = json.loads(json_data2)
+        if isinstance(json_data, dict):
+            for key, value in json_data.items():
+            
+                if key == "imsi":
+                    imsi.append(value)
+
+        remove = ['remove']
+
+        try:
+            if imsi:
+                delete_output = subprocess.check_output([script_path] + remove + imsi, text=True,
+                                                        stderr=subprocess.STDOUT)
+                if int(delete_output) > 0:
+                    result = "deleted"
+            print(ujson.dumps(result))
+
+        except subprocess.CalledProcessError as e:
+            pass
+
+    fetch()
+
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py.back
+++ b/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py.back
@@ -1,0 +1,52 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 0:
+    def fetch():
+        os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+        os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+        # print(os.environ)
+
+        script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+        imsi = []
+        x = sys.argv[1]
+        y = x.replace('[', "")
+        t = y.replace(']', '')
+        #    z = json.loads(t)
+        json_data = json.loads(t)
+        # print(type(json_data))
+        if isinstance(json_data, dict):
+            for key, value in json_data.items():
+                #      print(key)
+                if key == "imsi":
+                    imsi.append(value)
+
+        # print(imsi)
+
+        showAll = ['showfiltered']
+        remove = ['remove']
+
+        # Use subprocess to run the Bash script
+        user_details = []
+        dets = {}
+
+        try:
+            if imsi:
+                delete = subprocess.check_output([script_path] + remove + imsi, text=True, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            # print(f"Error running the Bash script: {e}")
+            # print(f"Command output: {e.output}")
+            pass
+
+    fetch()
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py.backup
+++ b/opncell/src/opnsense/scripts/opncore/opncore/deleteUser.py.backup
@@ -1,0 +1,78 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 0:
+    def fetch():
+        os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+        os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+        # print(os.environ)
+
+        script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+        imsi = []
+        x = sys.argv[1]
+        y = x.replace('[', "")
+        t = y.replace(']', '')
+        #    z = json.loads(t)
+        json_data = json.loads(t)
+        # print(type(json_data))
+        if isinstance(json_data, dict):
+            for key, value in json_data.items():
+                #      print(key)
+                if key == "imsi":
+                    imsi.append(value)
+
+        # print(imsi)
+
+        showAll = ['showfiltered']
+        remove = ['remove']
+
+        # Use subprocess to run the Bash script
+        user_details = []
+        dets = {}
+
+        try:
+            if imsi:
+                delete = subprocess.check_output([script_path] + remove + imsi, text=True, stderr=subprocess.STDOUT).strip().split('\n')
+               # output = delete.strip().split('\n')
+                #output_list = output_user.strip().split('\n')
+                print(output)
+
+                #output_json = json.loads(output)
+                #print(output_json)
+
+        except subprocess.CalledProcessError as e:
+            # print(f"Error running the Bash script: {e}")
+            # print(f"Command output: {e.output}")
+            pass
+    fetch()
+
+    # def check_delete_output(output):
+    #     try:
+    #         # Parse the JSON output
+    #         output_json = json.loads(output)
+    #
+    #         # Get the deletedCount value
+    #         deleted_count = output_json.get('deletedCount', 0)
+    #
+    #         # Check if deletedCount is greater than 0
+    #         if deleted_count > 0:
+    #             return "deleted"
+    #         else:
+    #             return "not deleted"
+    #     except json.JSONDecodeError:
+    #         return "invalid output"
+    #
+    # delete_output = fetch()
+    # result = check_delete_output(delete_output)
+    # print(result)
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/editSingleService.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/editSingleService.py
@@ -1,0 +1,103 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 1:
+
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+    json_data = json.loads(t)
+   # json_data = json.loads(json_data2)
+    # create a temporary directory with write permissions- to use for file editing
+    new_dir = '/tmp/yaml'
+    os.makedirs(new_dir, exist_ok=True)
+    os.chmod(new_dir, 0o777)
+    print(json_data)
+    print(type(json_data))
+    server = ''
+    pid = ''
+    new_addr = ''
+    configurableServices = ['sgwu', 'sgwc', 'amf', 'scp', 'pcf', 'nssf', 'smf', 'ausf', 'upf', 'mme']
+    if isinstance(json_data, dict):
+        for key, value in json_data.items():
+            if key == 'server':
+                server = value
+            if key == 'ip':
+                new_addr = value
+            if key == 'pid':
+                pid = value
+    #print(pid,server,new_addr)
+    def config(service_list, name, process_pid):
+        yaml_path = '/usr/ports/open5gs/install/etc/open5gs/'
+        process_name = name.strip('d')
+        print(process_name)
+        if process_name in service_list:
+            print(name) 
+            yaml_file = yaml_path + process_name + '.yaml'
+            # Copy the file to a directory where you have write permissions i.e /tmp/yaml .
+            # (/tmp/ folder because we copy the files back to where the service expects them, after the edit)
+
+            copy_file = f"cp {yaml_file} {new_dir}/"
+            os.system(copy_file)
+            new = '/tmp/yaml/' + process_name + '.yaml'
+            os.chmod(new, 0o777)  # make file writable as well
+
+            # Read the YAML file
+            with open(yaml_file, 'r') as file:
+                yaml_data = yaml.safe_load(file)
+
+            # Replace values in the configuration--It's faster to access individual elements than loop through
+            # the whole file
+
+            if process_name == 'sgwu':
+                yaml_data['sgwu']['gtpu']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'sgwc':
+                yaml_data['sgwc']['gtpc']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'amf':
+                yaml_data['amf']['ngap']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'mme':
+                yaml_data['mme']['s1ap']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'upf':
+                yaml_data['upf']['gtpu']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'ausf':
+                yaml_data['ausf']['sbi']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'smf':
+                yaml_data['smf']['gtpu']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'nssf':
+                yaml_data['nssf']['sbi']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'pcf':
+                yaml_data['pcf']['sbi']['server'][0]['address'] = new_addr.strip("'")
+
+            elif process_name == 'scp':
+                yaml_data['scp']['sbi']['server'][0]['address'] = new_addr.strip("'")
+
+            if process_pid != 0:
+                kill_command = "kill -9 " + process_pid
+                output = subprocess.run(kill_command, shell=True, text=True)
+
+            with open(new, 'w') as file:
+                yaml.safe_dump(yaml_data, file, sort_keys=False, default_flow_style=False)
+
+            copy_file = f"cp {new} {yaml_path}"
+            os.system(copy_file)
+
+            command = "/usr/ports/open5gs/install/bin/" + 'open5gs-' + name + " -D "
+            subprocess.run(command, shell=True, text=True)
+
+    config(configurableServices, server, pid)
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcamfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcamfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/amf.log  /var/log/opncore/amf.log
+chown -R $user:$group /var/log/opncore/amf.log
+chmod +r /var/log/opncore/amf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcausfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcausfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/ausf.log  /var/log/opncore/ausf.log
+chown -R $user:$group /var/log/opncore/ausf.log
+chmod +r /var/log/opncore/ausf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcbsfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcbsfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/bsf.log  /var/log/opncore/bsf.log
+chown -R $user:$group /var/log/opncore/bsf.log
+chmod +r /var/log/opncore/bsf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epchssd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epchssd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/hss.log  /var/log/opncore/hss.log
+chown -R $user:$group /var/log/opncore/hss.log
+chmod +r /var/log/opncore/hss.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcmmed_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcmmed_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/mme.log /var/log/opncore/mme.log
+chown -R $user:$group /var/log/opncore/mme.log
+chmod +r /var/log/opncore/mme.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcnrfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcnrfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/nrf.log  /var/log/opncore/nrf.log
+chown -R $user:$group /var/log/opncore/nrf.log
+chmod +r /var/log/opncore/nrf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcnssfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcnssfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/nssf.log  /var/log/opncore/nssf.log
+chown -R $user:$group /var/log/opncore/nssf.log
+chmod +r /var/log/opncore/nssf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcpcfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcpcfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/pcf.log  /var/log/opncore/pcf.log
+chown -R $user:$group /var/log/opncore/pcf.log
+chmod +r /var/log/opncore/pcf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcpcrfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcpcrfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/pcrf.log  /var/log/opncore/pcrf.log
+chown -R $user:$group /var/log/opncore/pcrf.log
+chmod +r /var/log/opncore/pcrf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcscpd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcscpd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/scp.log  /var/log/opncore/scp.log
+chown -R $user:$group /var/log/opncore/scp.log
+chmod +r /var/log/opncore/scp.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcsgwcd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcsgwcd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/sgwc.log  /var/log/opncore/sgwc.log
+chown -R $user:$group /var/log/opncore/sgwc.log
+chmod +r /var/log/opncore/sgwc.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcsgwud_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcsgwud_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/sgwu.log  /var/log/opncore/sgwu.log
+chown -R $user:$group /var/log/opncore/sgwu.log
+chmod +r /var/log/opncore/sgwu.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcsmfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcsmfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/smf.log  /var/log/opncore/smf.log
+chown -R $user:$group /var/log/opncore/smf.log
+chmod +r /var/log/opncore/smf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcudmd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcudmd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/udm.log  /var/log/opncore/udm.log
+chown -R $user:$group /var/log/opncore/udm.log
+chmod +r /var/log/opncore/udm.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcudrd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcudrd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/udr.log  /var/log/opncore/udr.log
+chown -R $user:$group /var/log/opncore/udr.log
+chmod +r /var/log/opncore/udr.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/epcupfd_setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/epcupfd_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile
+mkdir -p /var/log/opncore
+ln -s /usr/ports/open5gs/install/var/log/open5gs/upf.log  /var/log/opncore/upf.log
+chown -R $user:$group /var/log/opncore/upf.log
+chmod +r /var/log/opncore/upf.log

--- a/opncell/src/opnsense/scripts/opncore/opncore/genericInstall.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/genericInstall.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+
+# This script installs the generic requirements of the network ie, mongodb and open5gs along with its dependencies
+# Also starts the services required
+#Further install may be required.
+
+# Check if the script is run as root (or with sudo)
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root or with sudo."
+   exit 1
+fi
+
+echo "#############################################################"
+echo "The following packages are going to be Installed on your system."
+echo "-->> MongoDB plus all its dependencies"
+echo "-->> Open5GS plus all its dependencies"
+echo "##############################################################"
+printf "\n"
+echo "=====> Enabling SCTP support ............ Started"
+printf "\n"
+
+echo "=====> Activating custom repository ............ Started"
+printf "\n"
+
+touch /boot/loader.conf.local
+# shellcheck disable=SC2129
+echo sctp_load="YES" >>  /boot/loader.conf.local
+echo if_ix_updated_load="YES" >> /boot/loader.conf.local
+echo hw.if_ix_updated.unsupported_sfp=1 >> /boot/loader.conf.local
+echo hw.ix.unsupported_sfp=1 >> /boot/loader.conf.local
+echo hw.ixgbe.unsupported_sfp=1 >> /boot/loader.conf.local
+kldload sctp.ko
+
+printf '%b\n' "\033[1m"=====> Enabling SCTP support................................................... Done"\033[0m"
+
+echo DEVELOPER=yes >> /etc/make.conf
+
+printf '%b\n' "\033[1m"=====> Installing Nano ................................................... Starting"\033[0m"
+#if  ! pkg info -l nano; then
+  pkg install -y nano
+#fi
+#
+#if pkg info -l nano ; then
+#
+#printf '%b\n' "\033[1m"=====> Installing Nano ................................................... Done"\033[0m"
+#fi
+#printf "\n"
+
+#printf '%b\n' "\033[1m"=====> Updating OPNsense ports ................................................... Starting"\033[0m"
+#if opnsense-code tools ports src; then
+#  printf '%b\n' "\033[1m"=====> Updating OPNsense ports ................................................... Done"\033[0m"
+#else
+#  printf '%b\n' "\033[1m"=====> Updating OPNsense ports  ................................................... Done"\033[0m"
+#fi
+#printf "\n"
+
+printf '%b\n' "\033[1m"=====> Installing dependencies for Open5GS ................................................... Starting"\033[0m"
+
+printf "\n"
+echo "=====> installing cmake ............ Started"
+pkg install -y cmake
+printf "\n"
+echo "=====> installing ninja ............ Started"
+pkg install -y ninja
+printf "\n"
+echo "=====> installing bison ............ Started"
+pkg install -y bison
+printf "\n"
+echo "=====> installing pkgconf ............ Started"
+pkg install -y pkgconf
+printf "\n"
+echo "=====> installing git ............ Started"
+pkg install -y git
+printf "\n"
+echo "=====> installing gnutls ............ Started"
+pkg install -y gnutls
+printf "\n"
+echo "=====> installing libgcrypt ............ Started"
+pkg install -y libgcrypt
+printf "\n"
+echo "=====> installing libidn ............ Started"
+pkg install -y libidn
+printf "\n"
+echo "=====> installing libyaml ............ Started"
+pkg install -y libyaml
+printf "\n"
+echo "=====> installing talloc ............ Started"
+pkg install -y talloc
+printf "\n"
+echo "=====> installing gmake ............ Started"
+pkg install -y gmake
+printf "\n"
+echo "=====> installing texinfo ............ Started"
+pkg install -y texinfo
+
+printf '%b\n' "\033[1m"=====> Installing libmicrohttpd, nghttp2, mongo-c-driver, gsed, gcc ................................................... Starting"\033[0m"
+printf "\n"
+echo "=====> installing libmicrohttpd ............ Started"
+pkg install -y libmicrohttpd
+printf "\n"
+echo "=====> installing nghttp2 ............ Started"
+pkg install -y nghttp2
+printf "\n"
+echo "=====> installing mongo-c-driver ............ Started"
+pkg install -y mongo-c-driver
+printf "\n"
+echo "=====> installing gsed ............ Started"
+pkg install -y gsed
+printf "\n"
+echo "=====> installing gcc ............ Started"
+pkg install -y gcc
+
+printf '%b\n' "\033[1m"=====> Installing meson dependencies................................................... Starting"\033[0m"
+printf "\n"
+echo "=====> installing python39 ............ Started"
+pkg install -y python39
+printf "\n"
+echo "=====> installing py-setuptools ............ Started"
+pkg install -y py-setuptools
+printf "\n"
+echo "=====> installing py-wheel ............ Started"
+pkg install -y py-wheel
+printf "\n"
+echo "=====> installing py-build ............ Started"
+pkg install -y py-build
+printf "\n"
+echo "=====> installing py-installer ............ Started"
+pkg install -y py-installer
+printf "\n"
+echo "=====> installing py-pytest-xdist ............ Started"
+pkg install -y py-pytest-xdist
+printf "\n"
+echo "=====> installing py-setuptools_scm ............ Started"
+pkg install -y py-setuptools_scm
+printf "\n"
+echo "=====> installing meson ............ Started"
+pkg install -y meson
+
+wget -r -np -nH --cut-dirs=1 -P /root/ http://192.168.100.19/mongo/
+
+setenv LIBRARY_PATH /usr/local/lib
+setenv C_INCLUDE_PATH /usr/local/include
+
+# Download and compile Open5GS (example)
+printf '%b\n' "\033[1m"=====> Downloading and compiling Open5GS ................................................... Starting"\033[0m"
+printf "\n"
+
+mkdir -p /usr/ports
+
+cd /usr/ports/ || exit 1
+wget -r -np -nH --cut-dirs=1 -P /root/ http://192.168.100.19/open5gs/
+
+#git clone https://github.com/open5gs/open5gs.git
+
+cd /usr/ports/open5gs/subprojects/freeDiameter/include/freeDiameter || exit 1
+
+printf '%b\n' "\033[1m"=====> Editing Free diameter ................................................... Starting"\033[0m"
+
+filename="libfdproto.h"
+line_to_replace="static char * file_bname_init(char * full) { file_bname = basename(full); return file_bname; }"
+replacement_line="static char * file_bname_init(char * full) { file_bname = __old_basename(full); return file_bname; }"
+
+# Temporary file for storing modified content
+touch temp.txt
+tempfile=temp.txt
+#
+## Read the input file line by line
+while IFS= read -r line; do
+    # Check if the current line matches the line to replace
+    if [[ "$line" == "$line_to_replace" ]]; then
+        # Replace the line with the replacement line
+        echo "$replacement_line" >> "$tempfile"
+    else
+        # Keep the original line
+        echo "$line" >> "$tempfile"
+    fi
+done < "$filename"
+
+## Overwrite the original file with the modified content
+mv "$tempfile" "$filename"
+printf "\n"
+echo "=====> Editing Free diameter .................................................... Done"
+
+cd /usr/ports/open5gs || exit 1
+meson build --prefix=/usr/ports/open5gs/install
+ninja -C build
+cd build || exit 1
+meson test -v
+ninja install
+
+run_service() {
+    local service_name="$1"
+    local service_command="$2"
+
+    echo "Starting $service_name..."
+    cd "$service_command" || {
+        echo "Error: Failed to change directory to $service_name."
+        return 1
+    }
+
+    ./install/bin/"$service_name"
+
+    if [ $? -eq 0 ]; then
+        echo "$service_name started successfully."
+    else
+        echo "Error: Failed to start $service_name."
+    fi
+
+    cd /usr/ports/open5gs || exit 1 # Return to the previous directory
+}
+
+checkMongo() {
+
+    command="ps aux | grep mongod | awk '\$8 == \"I+\" || \$8 == \"Is\" || \$8 == \"T\" {print \$8}'"
+    status=$(eval "$command")
+    if test "$status" == "T"; then
+       pid_command="ps aux | grep mongod | awk '\$8 == \"T\" {print \$2}'"
+       pid=$(eval "$pid_command")
+       kill -9 "$pid"
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+      cd "$directory_path" || exit 1
+      mongod --dbpath ./data/db &
+  sleep 2
+    fi
+
+   if test -z  "$status" ; then
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+      cd "$directory_path" || exit 1
+      mkdir -p ./data/db
+      mongod --dbpath ./data/db &
+sleep 2
+ fi
+}
+
+checkMongo
+
+# Change to the directory where the services are located
+#cd /usr/ports/open5gs || exit 1
+
+# Start the services one by one
+#run_service "open5gs-nrfd" "./install/bin/open5gs-nrfd"
+#run_service "open5gs-scpd" "./install/bin/open5gs-scpd"
+#run_service "open5gs-amfd" "open5gs-amfd"
+#run_service "open5gs-smfd" "open5gs-smfd"
+#run_service "open5gs-upfd" "open5gs-upfd"
+#run_service "open5gs-ausfd" "./install/bin/open5gs-ausfd"
+
+echo "All services started."
+
+
+  echo "Installation complete."
+  echo "/n"
+  echo "The below loopback addresses should be enabled on the GUI"
+  echo "MongoDB   = 127.0.0.1 (subscriber data) - http://localhost:3000"
+  echo "MME-s1ap  = 127.0.0.2 :36412 for S1-MME"
+  echo "MME-gtpc  = 127.0.0.2 :2123 for S11"
+  echo "MME-frDi  = 127.0.0.2 :3868 for S6a"
+  echo "SGWC-gtpc = 127.0.0.3 :2123 for S11"
+  echo "SGWC-pfcp = 127.0.0.3 :8805 for Sxa"
+  echo "SMF-gtpc  = 127.0.0.4 :2123 for S5c, N11"
+  echo "SMF-gtpu  = 127.0.0.4 :2152 for N4u (Sxu)"
+  echo "SMF-pfcp  = 127.0.0.4 :8805 for N4 (Sxb)"
+ echo "SMF-frDi  = 127.0.0.4 :3868 for Gx auth"
+ echo "SMF-sbi   = 127.0.0.4 :7777 for 5G SBI (N7,N10,N11)"
+  echo "AMF-ngap  = 127.0.0.5 :38412 for N2"
+  echo "AMF-sbi   = 127.0.0.5 :7777 for 5G SBI (N8,N12,N11)"
+  echo "SGWU-pfcp = 127.0.0.6 :8805 for Sxa"
+  echo "SGWU-gtpu = 127.0.0.6 :2152 for S1-U, S5u"
+  echo "UPF-pfcp  = 127.0.0.7 :8805 for N4 (Sxb)"
+ echo "UPF-gtpu  = 127.0.0.7 :2152 for S5u, N3, N4u (Sxu) (needs to be changed to the interface hosting the xNBs)"
+  echo "HSS-frDi  = 127.0.0.8 :3868 for S6a, Cx"
+ echo  "PCRF-frDi = 127.0.0.9 :3868 for Gx"
+ echo  "NRF-sbi   = 127.0.0.10:7777 for 5G SBI"
+  echo "SCP-sbi   = 127.0.1.10:7777 for 5G SBI"
+ echo "AUSF-sbi  = 127.0.0.11:7777 for 5G SBI"
+ echo "UDM-sbi   = 127.0.0.12:7777 for 5G SBI"
+ echo "PCF-sbi   = 127.0.0.13:7777 for 5G SBI"
+echo   "NSSF-sbi  = 127.0.0.14:7777 for 5G SBI"
+echo "BSF-sbi   = 127.0.0.15:7777 for 5G SBI"
+  echo "UDR-sbi   = 127.0.0.20:7777 for 5G SBI"
+
+
+
+# Clean up (optional)
+# rm -rf /tmp/open5gs
+
+exit 0

--- a/opncell/src/opnsense/scripts/opncore/opncore/getUser.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/getUser.py
@@ -1,0 +1,74 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 0:
+    def fetch():
+        os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+        os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+        os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+        # print(os.environ)
+
+        script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+        imsi = []
+        x = sys.argv[1]
+        y = x.replace('[', "")
+        t = y.replace(']', '')
+       # z = json.loads(t)
+        json_data = json.loads(t)
+        #print(type(json_data))
+        if isinstance(json_data, dict):
+            for key, value in json_data.items():
+                if key == "imsi":
+                    imsi.append(value)
+        showAll = ['showfiltered']
+        showOne = ['showone']
+
+    # Use subprocess to run the Bash script
+        user_details = []
+        try:
+            if not imsi:
+                output = subprocess.check_output([script_path] + showAll, text=True, stderr=subprocess.STDOUT)
+            else:
+                output = subprocess.check_output([script_path] + showOne + imsi, text=True, stderr=subprocess.STDOUT)
+                #  Run the Bash script
+                output_list = output.strip().split('\n')
+                # Parse each JSON object separately
+                for json_str in output_list:
+                    try:
+                        data = json.loads(json_str)
+                        #print(data)
+                        imsi = data.get("imsi")
+                        k = data.get("security", {}).get("k")
+                        opc = data.get("security", {}).get("opc")
+                        slice_array = data.get("slice", [])
+                        names = []
+               # print(type(slice_array))
+                        for slice_data in slice_array:
+                   # print(slice_array)
+                            session_array = slice_data.get("session", [])
+                            for session_data in session_array:
+                                name = session_data.get("name")
+                                names.append(name)
+                #names = [session_data.get("name") for session_data in session]
+                            names_str = ",".join(names)
+                        dets = {"imsi": imsi, "ki": k, "opc": opc, "apn": names_str}
+                        user_details.append(dets)
+
+                    except json.JSONDecodeError as e:
+                        pass
+        except subprocess.CalledProcessError as e:
+            pass
+
+        print(ujson.dumps(user_details))
+
+    fetch()
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/hss.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/hss.sh
@@ -136,98 +136,11 @@ if [ "$1" = "add" ]; then
         exit $?
     fi
 
-    if [ "$#" -eq 14 ]; then
+    if [ "$#" -eq 5 ]; then
         IMSI=$2
-        KI=$3
-        OPC=$4
-        SST=$5
-        APN=$6
-        DL=$7
-        UNIT=$8
-        UL=$9
-        QOS=${10}
-        PRIORITY_LEVEL=${11}
-        ARP_CAPA=${12}
-        ARP_VUL=${13}
-        IP=${14}
-
-        mongo --eval "db.subscribers.insertOne(
-            {
-                \"_id\": new ObjectId(),
-                \"schema_version\": NumberInt(1),
-                \"imsi\": \"$IMSI\",
-                \"msisdn\": [],
-                \"imeisv\": [],
-                \"mme_host\": [],
-                \"mm_realm\": [],
-                \"purge_flag\": [],
-                \"slice\":[
-                {
-                    \"sst\": NumberInt($SST),
-                    \"default_indicator\": true,
-                    \"session\": [
-                    {
-                        \"name\" : \"$APN\",
-                        \"type\" : NumberInt(3),
-                        \"qos\" :
-                        { \"index\": NumberInt($QOS),
-                            \"arp\":
-                            {
-                                \"priority_level\" : NumberInt($PRIORITY_LEVEL),
-                                \"pre_emption_capability\": NumberInt($ARP_CAPA),
-                                \"pre_emption_vulnerability\": NumberInt($ARP_VUL)
-                            }
-                        },
-                        \"ambr\":
-                        {
-                            \"downlink\":
-                            {
-                                \"value\": NumberInt($DL),
-                                \"unit\": NumberInt($UNIT)
-                            },
-                            \"uplink\":
-                            {
-                                \"value\": NumberInt($UL),
-                                \"unit\": NumberInt($UNIT)
-                            }
-                        },
-                         \"ue\":
-                        {
-                            \"addr\": \"$IP\"
-                        },
-                        \"pcc_rule\": [],
-                        \"_id\": new ObjectId(),
-                    }],
-                    \"_id\": new ObjectId(),
-                }],
-                \"security\":
-                {
-                    \"k\" : \"$KI\",
-                    \"op\" : null,
-                    \"opc\" : \"$OPC\",
-                    \"amf\" : \"8000\",
-                },
-                \"ambr\" :
-                {
-                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\": NumberInt($UNIT)},
-                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\": NumberInt($UNIT)}
-                },
-                \"access_restriction_data\": 32,
-                \"network_access_mode\": 0,
-                \"subscriber_status\": 0,
-                \"operator_determined_barring\": 0,
-                \"subscribed_rau_tau_timer\": 12,
-                \"__v\": 0
-            }
-            );" $DB_URI
-        exit $?
-    fi
-
-    if [ "$#" -eq 4 ]; then
-        IMSI=$2
-
-        KI=$3
-        OPC=$4
+        IP=$3
+        KI=$4
+        OPC=$5
 
         mongo --eval "db.subscribers.insertOne(
             {
@@ -245,7 +158,7 @@ if [ "$1" = "add" ]; then
                     \"default_indicator\": true,
                     \"session\": [
                     {
-                        \"name\" : \"teal\",
+                        \"name\" : \"internet\",
                         \"type\" : NumberInt(3),
                         \"qos\" :
                         { \"index\": NumberInt(9),
@@ -268,6 +181,10 @@ if [ "$1" = "add" ]; then
                                 \"value\": NumberInt(1000000000),
                                 \"unit\": NumberInt(0)
                             }
+                        },
+                        \"ue\":
+                        {
+                            \"addr\": \"$IP\"
                         },
                         \"pcc_rule\": [],
                         \"_id\": new ObjectId(),
@@ -582,20 +499,7 @@ if [ "$1" = "remove" ]; then
     fi
 
     IMSI=$2
-    output=$(mongo --quiet --eval "db.subscribers.deleteOne({\"imsi\": \"$IMSI\"});" $DB_URI 2>/dev/null)
-    json_output=$(echo "$output" | awk '/{/,/}/')
-    deleted_count=$(echo "$json_output" | awk -F '[:,]' '{for(i=1;i<=NF;i++) if($i ~ /"deletedCount"/) print $(i+1)}')
-    #deleted_count=$(echo "$deleted_count" | tr -d '\n\r')
-    deleted_count=$(echo "$deleted_count" | awk '{$1=$1};1')
-    deleted_count=$(echo "$deleted_count" | cut -d' ' -f1)
-
-    deleted_count=$(echo "$deleted_count" | sed 's/0}$//')
-    #if [ -n "$deleted_count" ] && [ "$deleted_count" -gt 0 ]; then
-     #   echo "Document with IMSI $IMSI has been deleted."
-    #else
-     #   echo "No document with IMSI $IMSI found or deleted."
-    #fi
-    echo $deleted_count
+    mongo --eval "db.subscribers.deleteOne({\"imsi\": \"$IMSI\"});" $DB_URI
     exit $?
 fi
 
@@ -907,6 +811,43 @@ fi
 
 if [ "$1" = "set_apn" ]; then
     if [ "$#" -eq 11 ]; then
+            IMSI=$2
+            APN=$3
+            SST=$4
+            DL=$5
+            UNIT=$6
+            UL=$7
+            QOS=$8
+            PRIORITY_LEVEL=$9
+            ARP_CAPA=${10}
+            ARP_VUL=${11}
+
+           mongo --eval "db.subscribers.updateOne(
+              { \"imsi\": \"$IMSI\", \"slice.session.name\": \"$APN\" },  // Match documents with specified imsi and session name
+              {
+                  \$set: {
+
+                      \"slice.$[elem].session.$[subsession].ambr.uplink.value\": NumberInt($UL),
+                      \"slice.$[elem].session.$[subsession].ambr.downlink.value\": NumberInt($DL),
+                      \"slice.$[elem].session.$[subsession].ambr.uplink.unit\": NumberInt($UNIT),
+                      \"slice.$[elem].session.$[subsession].ambr.downlink.unit\": NumberInt($UNIT),
+                      \"slice.$[elem].session.$[subsession].qos.index\": NumberInt($QOS),
+                      \"slice.$[elem].session.$[subsession].qos.arp.priority_level\": NumberInt($PRIORITY_LEVEL),
+                      \"slice.$[elem].session.$[subsession].qos.arp.pre_emption_capability\": NumberInt($ARP_CAPA),
+                      \"slice.$[elem].session.$[subsession].qos.arp.pre_emption_vulnerability\": NumberInt($ARP_VUL),
+
+                  }
+              },
+              {
+                  arrayFilters: [
+                      { \"elem.session.name\": \"$APN\" },  // Filter for 'slice' elements with 'session' name specified by variable
+                      { \"subsession.name\": \"$APN\" }     // Filter for 'session' elements with name specified by variable
+                  ]
+              }
+          );" $DB_URI
+          exit $?
+    fi
+    if [ "$#" -eq 12 ]; then
         IMSI=$2
         APN=$3
         SST=$4
@@ -918,100 +859,39 @@ if [ "$1" = "set_apn" ]; then
         ARP_CAPA=${10}
         ARP_VUL=${11}
 
- mongo --eval "db.subscribers.updateOne(
-             {
-               'imsi': '$IMSI',
-               'slice.session.name': '$APN'
-             },
-             {
-               \$set: {
-                 'slice.$[s].session.$[se].qos.index': NumberInt($QOS),
-                 'slice.$[s].session.$[se].qos.arp.priority_level': NumberInt($PRIORITY_LEVEL),
-                 'slice.$[s].session.$[se].qos.arp.pre_emption_capability': NumberInt($ARP_CAPA),
-                 'slice.$[s].session.$[se].qos.arp.pre_emption_vulnerability': NumberInt($ARP_VUL),
-                 'slice.$[s].session.$[se].ambr.downlink.value': NumberInt($DL),
-                 'slice.$[s].session.$[se].ambr.downlink.unit': NumberInt($UNIT),
-                 'slice.$[s].session.$[se].ambr.uplink.value': NumberInt($UL)
-                 'slice.$[s].session.$[se].ambr.uplink.unit': NumberInt($UNIT)
-               }
-             },
-             {
-               arrayFilters: [
-                 { 's.session': { \$elemMatch: { 'name': '$APN' } } },
-                 { 'se.name': '$APN' }
-               ]
-             }
-           );" $DB_URI
 
-#        mongo --eval "db.subscribers.updateOne({\"imsi\": \"$IMSI\"},
-#            {\$set: {
-#                \"ambr\" : {
-#                    \"downlink\" : {
-#                        \"value\" : NumberInt($DL),
-#                        \"unit\"  : NumberInt($UNIT)
-#                    },
-#                    \"uplink\" :{
-#                        \"value\": NumberInt($UL),
-#                        \"unit\" : NumberInt($UNIT)
-#                    }
-#                },
-#                { \"slice.0.sst\": $SST
-#                },
-#                { \"slice.0.session.0.name\": $APN
-#                },
-#                \"slice.0.session.0.qos\": {
-#                      \"index\": $QOS,
-#                      \"arp\" : {
-#                          \"priority_level\" : NumberInt($PRIORITY_LEVEL),
-#                          \"pre_emption_capability\"  : NumberInt($ARP_CAPA),
-#                          \"pre_emption_vulnerability\"  : NumberInt($ARP_VUL)
-#                      }
-#                  },
-#                \"slice.0.session.0.ambr\": {
-#                    \"downlink\" : {
-#                        \"value\" : NumberInt($DL),
-#                        \"unit\"  : NumberInt($UNIT)
-#                    },
-#                    \"uplink\" :{
-#                        \"value\": NumberInt($UL),
-#                        \"unit\" : NumberInt($UNIT)
-#                    }
-#                }
-#                     }
-#            });" $DB_URI
+        mongo --eval "db.subscribers.updateOne({ \"imsi\": \"$IMSI\"},
+            {\$set: { \"slice\":
 
-#        mongo --eval "db.subscribers.updateOne({ \"imsi\": \"$IMSI\"},
-#            {\$set: { \"slice\":
-#
-#                            {
-#                            \"sst\" : NumberInt($SST),
-#                            \"default_indicator\" : false,
-#                            \"_id\" : new ObjectId(),
-#                            \"session\" :
-#                            [{
-#                                \"name\" : \"$APN\",
-#                                \"type\" : NumberInt(3),
-#                                \"_id\" : new ObjectId(),
-#                                \"pcc_rule\" : [],
-#                                \"ambr\" :
-#                                {
-#                                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\" : NumberInt($UNIT) },
-#                                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\" : NumberInt($UNIT) },
-#                                },
-#                                \"qos\" :
-#                                {
-#                                    \"index\" : NumberInt($QOS),
-#                                    \"arp\" :
-#                                    {
-#                                        \"priority_level\" : NumberInt($PRIORITY_LEVEL),
-#                                        \"pre_emption_capability\" : NumberInt($ARP_CAPA),
-#                                        \"pre_emption_vulnerability\" : NumberInt($ARP_VUL),
-#                                    },
-#                                },
-#                             }]
-#                            }
-#                    }
-#            });" $DB_URI
+                            {
+                            \"sst\" : NumberInt($SST),
+                            \"default_indicator\" : false,
+                            \"_id\" : new ObjectId(),
+                            \"session\" :
+                            [{
+                                \"name\" : \"$APN\",
+                                \"type\" : NumberInt(3),
+                                \"_id\" : new ObjectId(),
+                                \"pcc_rule\" : [],
+                                \"ambr\" :
+                                {
+                                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\" : NumberInt($UNIT) },
+                                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\" : NumberInt($UNIT) },
+                                },
+                                \"qos\" :
+                                {
+                                    \"index\" : NumberInt($QOS),
+                                    \"arp\" :
+                                    {
+                                        \"priority_level\" : NumberInt($PRIORITY_LEVEL),
+                                        \"pre_emption_capability\" : NumberInt($ARP_CAPA),
+                                        \"pre_emption_vulnerability\" : NumberInt($ARP_VUL),
+                                    },
+                                },
+                             }]
+                            }
+                    }
+            });" $DB_URI
         exit $?
     fi
 
@@ -1085,6 +965,7 @@ if [ "$1" = "ambr_speed" ]; then
                 }
                      }
             });" $DB_URI
+
 
         exit $?
     fi

--- a/opncell/src/opnsense/scripts/opncore/opncore/mongo.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/mongo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+checkMongo() {
+    
+    command="ps aux | grep mongod | awk '\$8 == \"I+\" || \$8 == \"Is\" || \$8 == \"T\" {print \$8}'"
+    status=$(eval "$command")    
+    echo $status
+    if test "$status" == "T"   ; then
+       pid_command="ps aux | grep mongod | awk '\$8 == \"T\" {print \$2}'"
+       pid=$(eval "$pid_command")
+      kill -9 $pid
+      echo $pid
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+     # echo $directory_path
+      cd $directory_path || exit 1
+     mkdir -p ./data/db
+     #chmod +x ./data/db
+     mongod --dbpath ./data/db &
+  sleep 2      
+    fi
+
+   if test -z  "$status" ; then
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+     # echo $directory_path
+      cd $directory_path || exit 1
+     mkdir -p ./data/db
+     #chmod +x ./data/db
+     mongod --dbpath ./data/db &
+sleep 2
+ fi
+}
+
+checkMongo

--- a/opncell/src/opnsense/scripts/opncore/opncore/opncore_db.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/opncore_db.sh
@@ -919,23 +919,23 @@ if [ "$1" = "set_apn" ]; then
         ARP_VUL=${11}
 
  mongo --eval "db.subscribers.updateOne(
-             {
+             { 
                'imsi': '$IMSI',
                'slice.session.name': '$APN'
              },
-             {
-               \$set: {
+             { 
+               \$set: { 
                  'slice.$[s].session.$[se].qos.index': NumberInt($QOS),
                  'slice.$[s].session.$[se].qos.arp.priority_level': NumberInt($PRIORITY_LEVEL),
                  'slice.$[s].session.$[se].qos.arp.pre_emption_capability': NumberInt($ARP_CAPA),
                  'slice.$[s].session.$[se].qos.arp.pre_emption_vulnerability': NumberInt($ARP_VUL),
                  'slice.$[s].session.$[se].ambr.downlink.value': NumberInt($DL),
                  'slice.$[s].session.$[se].ambr.downlink.unit': NumberInt($UNIT),
-                 'slice.$[s].session.$[se].ambr.uplink.value': NumberInt($UL)
+                 'slice.$[s].session.$[se].ambr.uplink.value': NumberInt($UL),
                  'slice.$[s].session.$[se].ambr.uplink.unit': NumberInt($UNIT)
                }
              },
-             {
+             { 
                arrayFilters: [
                  { 's.session': { \$elemMatch: { 'name': '$APN' } } },
                  { 'se.name': '$APN' }

--- a/opncell/src/opnsense/scripts/opncore/opncore/opncore_db.sh.back
+++ b/opncell/src/opnsense/scripts/opncore/opncore/opncore_db.sh.back
@@ -135,7 +135,7 @@ if [ "$1" = "add" ]; then
             );" $DB_URI
         exit $?
     fi
-
+    
     if [ "$#" -eq 14 ]; then
         IMSI=$2
         KI=$3
@@ -225,7 +225,7 @@ if [ "$1" = "add" ]; then
 
     if [ "$#" -eq 4 ]; then
         IMSI=$2
-
+        
         KI=$3
         OPC=$4
 
@@ -588,7 +588,7 @@ if [ "$1" = "remove" ]; then
     #deleted_count=$(echo "$deleted_count" | tr -d '\n\r')
     deleted_count=$(echo "$deleted_count" | awk '{$1=$1};1')
     deleted_count=$(echo "$deleted_count" | cut -d' ' -f1)
-
+   
     deleted_count=$(echo "$deleted_count" | sed 's/0}$//')
     #if [ -n "$deleted_count" ] && [ "$deleted_count" -gt 0 ]; then
      #   echo "Document with IMSI $IMSI has been deleted."
@@ -918,100 +918,38 @@ if [ "$1" = "set_apn" ]; then
         ARP_CAPA=${10}
         ARP_VUL=${11}
 
- mongo --eval "db.subscribers.updateOne(
-             {
-               'imsi': '$IMSI',
-               'slice.session.name': '$APN'
-             },
-             {
-               \$set: {
-                 'slice.$[s].session.$[se].qos.index': NumberInt($QOS),
-                 'slice.$[s].session.$[se].qos.arp.priority_level': NumberInt($PRIORITY_LEVEL),
-                 'slice.$[s].session.$[se].qos.arp.pre_emption_capability': NumberInt($ARP_CAPA),
-                 'slice.$[s].session.$[se].qos.arp.pre_emption_vulnerability': NumberInt($ARP_VUL),
-                 'slice.$[s].session.$[se].ambr.downlink.value': NumberInt($DL),
-                 'slice.$[s].session.$[se].ambr.downlink.unit': NumberInt($UNIT),
-                 'slice.$[s].session.$[se].ambr.uplink.value': NumberInt($UL)
-                 'slice.$[s].session.$[se].ambr.uplink.unit': NumberInt($UNIT)
-               }
-             },
-             {
-               arrayFilters: [
-                 { 's.session': { \$elemMatch: { 'name': '$APN' } } },
-                 { 'se.name': '$APN' }
-               ]
-             }
-           );" $DB_URI
 
-#        mongo --eval "db.subscribers.updateOne({\"imsi\": \"$IMSI\"},
-#            {\$set: {
-#                \"ambr\" : {
-#                    \"downlink\" : {
-#                        \"value\" : NumberInt($DL),
-#                        \"unit\"  : NumberInt($UNIT)
-#                    },
-#                    \"uplink\" :{
-#                        \"value\": NumberInt($UL),
-#                        \"unit\" : NumberInt($UNIT)
-#                    }
-#                },
-#                { \"slice.0.sst\": $SST
-#                },
-#                { \"slice.0.session.0.name\": $APN
-#                },
-#                \"slice.0.session.0.qos\": {
-#                      \"index\": $QOS,
-#                      \"arp\" : {
-#                          \"priority_level\" : NumberInt($PRIORITY_LEVEL),
-#                          \"pre_emption_capability\"  : NumberInt($ARP_CAPA),
-#                          \"pre_emption_vulnerability\"  : NumberInt($ARP_VUL)
-#                      }
-#                  },
-#                \"slice.0.session.0.ambr\": {
-#                    \"downlink\" : {
-#                        \"value\" : NumberInt($DL),
-#                        \"unit\"  : NumberInt($UNIT)
-#                    },
-#                    \"uplink\" :{
-#                        \"value\": NumberInt($UL),
-#                        \"unit\" : NumberInt($UNIT)
-#                    }
-#                }
-#                     }
-#            });" $DB_URI
-
-#        mongo --eval "db.subscribers.updateOne({ \"imsi\": \"$IMSI\"},
-#            {\$set: { \"slice\":
-#
-#                            {
-#                            \"sst\" : NumberInt($SST),
-#                            \"default_indicator\" : false,
-#                            \"_id\" : new ObjectId(),
-#                            \"session\" :
-#                            [{
-#                                \"name\" : \"$APN\",
-#                                \"type\" : NumberInt(3),
-#                                \"_id\" : new ObjectId(),
-#                                \"pcc_rule\" : [],
-#                                \"ambr\" :
-#                                {
-#                                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\" : NumberInt($UNIT) },
-#                                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\" : NumberInt($UNIT) },
-#                                },
-#                                \"qos\" :
-#                                {
-#                                    \"index\" : NumberInt($QOS),
-#                                    \"arp\" :
-#                                    {
-#                                        \"priority_level\" : NumberInt($PRIORITY_LEVEL),
-#                                        \"pre_emption_capability\" : NumberInt($ARP_CAPA),
-#                                        \"pre_emption_vulnerability\" : NumberInt($ARP_VUL),
-#                                    },
-#                                },
-#                             }]
-#                            }
-#                    }
-#            });" $DB_URI
+        mongo --eval "db.subscribers.updateOne({ \"imsi\": \"$IMSI\"},
+            {\$set:{ \"slice\":
+                            [{
+                            \"sst\" : NumberInt($SST),
+                            \"default_indicator\" : false,
+                            \"_id\" : new ObjectId(),
+                            \"session\" :
+                            [{
+                                \"name\" : \"$APN\",
+                                \"type\" : NumberInt(3),
+                                \"_id\" : new ObjectId(),
+                                \"pcc_rule\" : [],
+                                \"ambr\" :
+                                {
+                                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\" : NumberInt($UNIT) },
+                                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\" : NumberInt($UNIT) },
+                                },
+                                \"qos\" :
+                                {
+                                    \"index\" : NumberInt($QOS),
+                                    \"arp\" :
+                                    {
+                                        \"priority_level\" : NumberInt($PRIORITY_LEVEL),
+                                        \"pre_emption_capability\" : NumberInt($ARP_CAPA),
+                                        \"pre_emption_vulnerability\" : NumberInt($ARP_VUL),
+                                    },
+                                },
+                             }]
+                            }]
+                    }
+            });" $DB_URI
         exit $?
     fi
 
@@ -1085,6 +1023,7 @@ if [ "$1" = "ambr_speed" ]; then
                 }
                      }
             });" $DB_URI
+
 
         exit $?
     fi

--- a/opncell/src/opnsense/scripts/opncore/opncore/processNames.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/processNames.py
@@ -1,0 +1,111 @@
+#!/usr/local/bin/python3
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+
+if len(sys.argv) > 1:
+
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+    json_data = json.loads(t)
+    process_names = []
+    running_processes_names = []
+    network = ""
+
+    if isinstance(json_data, dict):
+      #  print(json_data)
+        try:
+            for key, value in json_data.items():
+                if key == "network":
+                    network = str(value)
+        except:
+            pass
+    
+    # print(network)
+    result_dict = {}
+    # Define the target keys
+    target_keys = ['metrics','dns','tai','network_name','nsi','s1ap','ngap']
+    
+    fourGServices = ["hss", "mme", "pcrf",  "sgwu", "sgwc","smf", "upf"]
+    fiveNSAGServices = ["hss", "mme","pcrf",  "sgwu",  "sgwc","smf",  "upf"]
+    fiveGSAServices = ["nrf", "scp", "amf", "smf", "upf", "ausf", "udm", "udr","pcf", "nssf","bsf"]
+    
+    
+    def extract_nested_key_value(data, target_keys, current_key=''):
+        extracted_data = {}
+        for key, value in data.items():
+            new_key = f'{current_key}.{key}' if current_key else key
+            if isinstance(value, dict):
+                extracted_data.update(extract_nested_key_value(value, target_keys, new_key))
+            elif value == 'server':
+                nested_key = value
+                extracted_data.update(extract_nested_key_value(value, target_keys, nested_key))
+            elif isinstance(value, list):
+                extracted_data[new_key] = value
+            elif key in target_keys:
+                extracted_data[new_key] = value
+        return extracted_data
+    
+    
+    def running_processes():
+        command = "ps aux | grep open5gs | awk '$8 == \"Is\" || $8 == \"Ss\" || $8 == \"Rs\" {print $2}'"
+       # command_mongo = "ps aux | grep mongod | awk '$8 == \"Is\" || $8 == \"I\" || $8 == \"S\" {print $2}'"
+        command_mongo = "ps aux | grep mongod | grep -v grep | awk '{print $2}' | head -n 1"
+        output = subprocess.check_output(command, shell=True, text=True)
+        output_mongo = subprocess.check_output(command_mongo, shell=True, text=True)
+        pid_list = output.strip().split("\n")
+       # print(output_mongo)
+        try:
+            pid_mongo = output_mongo.strip().split("\n")
+            process_name_mongo = subprocess.check_output(f"ps -p {pid_mongo[0]} -o comm=", shell=True, text=True).strip()
+            p = {"PID":pid_mongo[0], "Name":process_name_mongo, "config":{"mongod.bind": [{"address":"127.0.0.1"}]}}
+        except:
+            #pass
+            p = {"PID": "Stopped", "Name": "mongod", "config":{"mongod.bind": [{"address":"127.0.0.1"}]}}
+        # Iterate through the list of PIDs
+        for pid in pid_list:
+            try:
+                process_name = subprocess.check_output(f"ps -p {pid} -o comm=", shell=True, text=True).strip()
+                name = process_name.replace("open5gs-", "").rstrip("d")
+                yaml_file_path = '/usr/ports/open5gs/install/etc/open5gs/' + name + '.yaml'
+    
+                with open(yaml_file_path, 'r') as file:
+                    yaml_data = yaml.safe_load(file)
+                    extracted_data = extract_nested_key_value(yaml_data, target_keys)
+    
+                process_info = {"PID": pid, "Name": name, "config": extracted_data}
+                running_processes_names.append(name)
+    
+                process_names.append(process_info)
+    
+            except subprocess.CalledProcessError:
+                pass
+             #   print(f"Process with PID {pid} does not exist or an error occurred")
+        try:
+            not_running_processes = {}
+            if network == 'enablefour':
+                difference_set = set(fourGServices) - set(running_processes_names)
+                not_running_processes = list(difference_set)
+            elif network == 'enablefiveSA':
+                difference_set = set(fiveGSAServices) - set(running_processes_names)
+                not_running_processes = list(difference_set)
+            elif network == 'enablefiveNSA':
+                difference_set = set(fiveNSAGServices) - set(running_processes_names)
+                not_running_processes = list(difference_set)
+    
+            for process in not_running_processes:
+                pr = {"PID": "Stopped", "Name": process}
+                process_names.append(pr)
+            process_names.append(p)
+        except:
+            pass
+        print(ujson.dumps(process_names))
+        # print(ujson.dumps(pid_mongo))
+    
+        return process_names
+    running_processes()
+else:
+    print("No arguments")

--- a/opncell/src/opnsense/scripts/opncore/opncore/reconfigure.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/reconfigure.py
@@ -1,0 +1,183 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+if len(sys.argv) > 1:
+
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+    json_data = json.loads(t)
+    #json_data = json.loads(json_data2)
+   # print(type(json_data))
+    # create a temporary directory with write permissions- to use for file editing
+    new_dir = '/tmp/yaml'
+    os.makedirs(new_dir, exist_ok=True)
+    os.chmod(new_dir, 0o777)
+
+    if "general" in json_data and isinstance(json_data["general"], dict):
+        new_addr = ''
+        new_mcc = ''
+        for key, value in json_data["general"].items():
+            if key == 'sst':
+                sst = value
+            if key == 'tac':
+                new_tac = value
+            if key == 'mcc':
+                new_mcc = value
+            if key == 'mnc':
+                new_mnc = value
+            if key == 's1ap':
+                new_addr = value
+            if key == 'ue':
+                ue = value
+            if key == 'peer':
+                peer = value
+            if key == 'network':
+                network = value
+            if key == 'network_name':
+                network_name = value
+
+
+
+    def running_processes():
+        command = "ps aux | grep open5gs | awk '$8 == \"Is\" || $8 == \"Ss\" || $8 == \"Rs\" {print $2}'"
+        output = subprocess.check_output(command, shell=True, text=True)
+
+        pid_list = output.strip().split("\n")
+        process_names = []
+
+        # Iterate through the list of PIDs
+        for pid in pid_list:
+            try:
+                process_name = subprocess.check_output(f"ps -p {pid} -o comm=", shell=True, text=True).strip()
+
+                process_info = {"PID": pid, "Name": process_name}
+                process_names.append(process_info)
+
+            except subprocess.CalledProcessError:
+                print(f"Process with PID {pid} does not exist or an error occurred")
+        # print(ujson.dumps(process_names))
+
+        return process_names
+
+
+    pList = running_processes()
+
+
+    def config(service_list, process_name, pid, name):
+        yaml_path = '/usr/ports/open5gs/install/etc/open5gs/'
+        if process_name in service_list:
+            yaml_file = yaml_path + process_name + '.yaml'
+            # Copy the file to a directory where you have write permissions i.e /tmp/yaml .
+            # (/tmp/ folder because we copy the files back to where the service expects them, after the edit)
+
+            copy_file = f"cp {yaml_file} {new_dir}/"
+            os.system(copy_file)
+            new = '/tmp/yaml/' + process_name + '.yaml'
+            os.chmod(new, 0o777)  # make file writable as well
+
+            # Read the YAML file
+            with open(yaml_file, 'r') as file:
+                yaml_data = yaml.safe_load(file)
+
+            # Replace values in the configuration--It's faster to access individual elements than loop through
+            # the whole file
+            if process_name == 'sgwu':
+                yaml_data['sgwu']['gtpu']['server'][0]['address'] = new_addr.strip("'")
+                yaml_data['global']['max']['ue'] = ue
+                yaml_data['global']['max']['peer'] = peer
+                yaml_data['logger']['file']['level'] = "debug"
+
+            # if process_name == 'sgwc':
+            #     yaml_data['sgwc']['gtpc']['server'][0]['address'] = new_addr.strip("'")
+
+            if process_name == 'nrf':
+                yaml_data['nrf']['serving'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['nrf']['serving'][0]['plmn_id']['mnc'] = new_mnc
+                yaml_data['global']['max']['ue'] = ue
+                yaml_data['global']['max']['peer'] = peer
+                yaml_data['logger']['file']['level'] = "debug"
+
+            if process_name == 'amf':
+                yaml_data['amf']['ngap']['server'][0]['address'] = new_addr.strip("'")
+                yaml_data['amf']['guami'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['amf']['guami'][0]['plmn_id']['mnc'] = new_mnc
+                yaml_data['amf']['tai'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['amf']['tai'][0]['plmn_id']['mnc'] = new_mnc
+                yaml_data['amf']['plmn_support'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['amf']['plmn_support'][0]['plmn_id']['mnc'] = new_mnc
+                yaml_data['amf']['tai'][0]['tac'] = int(new_tac)
+                yaml_data['amf']['network_name']['full'] = network_name
+                yaml_data['logger']['file']['level'] = "debug"
+                yaml_data['global']['max']['ue'] = ue
+                yaml_data['global']['max']['peer'] = peer
+
+            if process_name == 'mme':
+                yaml_data['mme']['tai'][0]['tac'] = int(new_tac)
+                yaml_data['mme']['s1ap']['server'][0]['address'] = new_addr.strip("'")
+                yaml_data['mme']['gummei'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['mme']['gummei'][0]['plmn_id']['mnc'] = new_mnc
+                yaml_data['mme']['tai'][0]['plmn_id']['mcc'] = new_mcc
+                yaml_data['mme']['tai'][0]['plmn_id']['mnc'] =  new_mnc
+                yaml_data['mme']['network_name']['full'] = network_name
+                yaml_data['logger']['file']['level'] = "debug"
+                yaml_data['global']['max']['ue'] = ue
+                yaml_data['global']['max']['peer'] = peer
+
+            if pid != 0:
+                kill_command = "kill -9 " + pid
+                output = subprocess.run(kill_command, shell=True, text=True)
+
+            with open(new, 'w') as file:
+                yaml.safe_dump(yaml_data, file,sort_keys=False, default_style=None, default_flow_style=False)
+
+            copy_file = f"cp {new} {yaml_path}"
+            os.system(copy_file)
+
+            command = "/usr/ports/open5gs/install/bin/" + name + " -D "
+            subprocess.run(command, shell=True, text=True)
+
+
+    def configureProcess(process_name, pid, name):
+
+        configurableServices = ['sgwu', 'sgwc', 'amf']
+        configurableFourServices = ['mme', 'sgwu', 'sgwc']
+
+        if network == 'enablefour':
+            config(configurableFourServices, process_name, pid, name)
+        else:
+            config(configurableServices, process_name, pid, name)
+
+
+    def reconfigure(process_list):
+        # only edit what needs to be edited. mme + sgwu for 4g and 5g-nsa networks. amf + sgwc for 5gsa networks
+        runningProcesses = []
+        configurableServices = ['mme', 'sgwu', 'sgwc', 'amf']
+        for process in process_list:
+            name = process.get("Name", "")
+            pid = process.get("PID", "")
+            process_name = name.replace("open5gs-", "").rstrip("d")
+            runningProcesses.append(process_name)
+            configureProcess(process_name, pid, name)
+
+        # get the processes that should be reconfigured, but they weren't running initially.
+
+        difference_set = set(configurableServices) - set(runningProcesses)
+        not_running_processes = list(difference_set)
+        d = set(runningProcesses) - set(configurableServices)
+        n_r = list(d)
+        final_list = n_r + not_running_processes
+        for process in final_list:
+            name = "open5gs-" + process + "d"
+            configureProcess(process, 0, name)
+
+
+    reconfigure(pList)
+else:
+    print("No arguments passed")

--- a/opncell/src/opnsense/scripts/opncore/opncore/saveUsers.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/saveUsers.py
@@ -1,0 +1,176 @@
+#!/usr/local/bin/python3
+
+import subprocess
+import sys
+import json
+import os
+import ast
+import ujson
+
+os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+
+if len(sys.argv) > 0:
+    script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+
+    json_data = json.loads(t)
+    #json_data = json.loads(json_data2)
+    #print(type(json_data))
+    imsi = []
+    num_profiles = 0
+    ki = []
+    opc = []
+    ip = []
+    arp_priority = []
+    dl = []
+    unit = ['2']  # 2 - Mbps
+    ul = []
+    arp_capability = []
+    arp_vulnerability = []
+    qos = []
+    apn = []
+    sst = []
+    apn_dict = {}
+    my_list = []
+    new_slice = False
+    result = "Failed"
+    def append_index(append_key, var_value, var_index):
+        result = append_key + var_index
+
+        if result not in apn_dict:
+            apn_dict[result] = []
+        apn_dict[result].append(var_value)
+
+
+    def otherAPNS(var_apn, var_index):
+        global new_slice
+        for var_key, var_value in var_apn.items():
+            if var_key == "sst":
+                append_index(var_key, var_value, var_index)
+                if var_value != sst[0]:
+                    new_slice = True
+            if var_key == "apn":
+                append_index(var_key, var_value, var_index)
+            if var_key == "dl":
+                append_index(var_key, var_value, var_index)
+            if var_key == "ul":
+                append_index(var_key, var_value, var_index)
+            if var_key == "QoS":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_priority":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_capability":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_vulnerability":
+               append_index(var_key, var_value, var_index)
+        print (new_slice)
+        if new_slice:
+            # Add slice to existing UE
+            subprocess.check_output(
+                [script_path] + ['update_slice'] + imsi + apn_dict['apn' + var_index] + apn_dict['sst' + var_index] +
+                apn_dict['dl' + var_index] + unit + apn_dict['ul' + var_index]
+                + apn_dict['QoS' + var_index] + apn_dict['arp_priority' + var_index] + apn_dict[
+                    'arp_capability' + var_index] + apn_dict['arp_vulnerability' + var_index],
+                text=True, stderr=subprocess.STDOUT)
+        else:
+            # add an apn to already existent UE
+            # print(apn_dict['apn' + var_index])
+            subprocess.check_output(
+                [script_path] + ['update_apn'] + imsi + apn_dict['apn' + var_index] + apn_dict['sst' + var_index] +
+                apn_dict['dl' + var_index] + unit + apn_dict['ul' + var_index]
+                + apn_dict['QoS' + var_index] + apn_dict['arp_priority' + var_index] + apn_dict[
+                    'arp_capability' + var_index] + apn_dict['arp_vulnerability' + var_index],
+                text=True, stderr=subprocess.STDOUT)
+
+
+    if isinstance(json_data, dict):
+        try:
+            num_profiles = json_data['count']
+            firstAPN = json_data['1']
+           # print(firstAPN)
+            for key, value in firstAPN.items():
+                if key == "imsi":
+                    imsi.append(str(value))
+                if key == "ki":
+                    ki.append(str(value))
+                if key == "opc":
+                    opc.append(str(value))
+                if key == "sst":
+                    sst.append(str(value))
+                if key == "apn":
+                    if value != "":
+                        apn.append(str(value))
+                if key == "ip":
+                    if value != "":
+                        ip.append(str(value))
+                if key == "dl":
+                    if value != " ":
+                        dl.append(str(value))
+                if key == "unit":
+                    if value != "":
+                        unit.append(str(value))
+                if key == "ul":
+                    if value != "":
+                        ul.append(str(value))
+                if key == "QoS":
+                    if value != "":
+                        qos.append(str(value))
+                if key == "arp_priority":
+                    if value != "":
+                        arp_priority.append(str(value))
+                if key == "arp_capability":
+                    if value != "":
+                        arp_capability.append(str(value))
+                if key == "arp_vulnerability":
+                    if value != "":
+                        arp_vulnerability.append(str(value))
+
+           # print(imsi, ki, opc, sst, apn, dl, unit, ul, qos, arp_priority, arp_capability, arp_vulnerability)
+
+            if len(ip) > 0:
+
+                output = subprocess.check_output([script_path] + ['add'] + imsi + ki + opc + sst + apn + dl + unit + ul
+                                                 + qos + arp_priority + arp_capability + arp_vulnerability + ip,
+                                                 text=True, stderr=subprocess.STDOUT)
+            else:
+                output = subprocess.check_output([script_path] + ['add'] + imsi + ki + opc + sst + apn + dl + unit + ul
+                                                 + qos + arp_priority + arp_capability + arp_vulnerability,
+                                                 text=True, stderr=subprocess.STDOUT)
+            # print(ujson.dumps(output))
+            # After creating the UE, then add the other apns, (if they exist)
+            for i in range(2, num_profiles + 1):
+                for key, value in json_data.items():
+                    if key == str(i):
+                        otherAPNS(value, str(i))
+
+            output_user = subprocess.check_output([script_path] + ['showone'] + imsi, text=True,
+                                                  stderr=subprocess.STDOUT)
+            output_list = output_user.strip().split('\n')
+            # print(output_list)
+            result = "Failed"
+            imsi_r = ""
+            for json_str in output_list:
+                try:
+                    data = json.loads(json_str)
+                    # print(data)
+
+                    imsi_r = data.get("imsi")
+                    # k = data.get("security", {}).get("k")
+                    # opc = data.get("security", {}).get("opc")
+                    # dets = {"imsi": imsi, "ki": k, "opc": opc}
+                    # user_details.append(dets)
+
+                except json.JSONDecodeError as e:
+                    pass
+            if imsi_r != "":
+                result = "Success"
+        except:
+            pass
+        print(ujson.dumps(result))
+

--- a/opncell/src/opnsense/scripts/opncore/opncore/saveUsers.py.backup
+++ b/opncell/src/opnsense/scripts/opncore/opncore/saveUsers.py.backup
@@ -1,0 +1,148 @@
+#!/usr/local/bin/python3
+
+import subprocess
+import sys
+import json
+import os
+import ast
+import ujson
+
+os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+
+if len(sys.argv) > 0:
+    script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+
+    print(t)
+    print(type(t))
+    json_data = json.loads(t)
+    #print(ujson.dumps(json_data2))
+    #print(type(json_data2))
+    #json_data = json.loads(json_data2)
+
+    imsi = []
+    num_profiles = 0
+    ki = []
+    opc = []
+    ip = ['None']
+    arp_priority = []
+    dl = []
+    unit = ['2']  # 2 - Mbps
+    ul = []
+    arp_capability = []
+    arp_vulnerability = []
+    qos = []
+    apn = []
+    sst = []
+    apn_dict = {}
+    my_list = []
+    new_slice = False
+
+    def append_index(append_key, var_value, var_index):
+        result = append_key + var_index
+
+        if result not in apn_dict:
+            # If not, create a new list for that key
+            apn_dict[result] = []
+        # Append the var_value to the list associated with the key
+        apn_dict[result].append(var_value)
+
+    def otherAPNS(var_apn, var_index):
+        global new_slice
+        for var_key, var_value in var_apn.items():
+            if var_key == "sst":
+                append_index(var_key, var_value, var_index)
+                if var_value != sst[0]:
+                    new_slice = True
+            if var_key == "apn":
+                append_index(var_key, var_value, var_index)
+            if var_key == "dl":
+                append_index(var_key, var_value, var_index)
+            if var_key == "ul":
+                append_index(var_key, var_value, var_index)
+            if var_key == "QoS":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_priority":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_capability":
+                append_index(var_key, var_value, var_index)
+            if var_key == "arp_vulnerability":
+                append_index(var_key, var_value, var_index)
+
+        if new_slice:
+            # Add slice to existing UE
+            subprocess.check_output(
+                [script_path] + ['update_slice'] + imsi + apn_dict['apn' + var_index] + apn_dict['sst' + var_index] +
+                apn_dict['dl' + var_index] + unit + apn_dict['ul' + var_index]
+                + apn_dict['QoS' + var_index] + apn_dict['arp_priority' + var_index] + apn_dict[
+                    'arp_capability' + var_index] + apn_dict['arp_vulnerability' + var_index],
+                text=True, stderr=subprocess.STDOUT)
+        else:
+            # add an apn to already existent UE
+            subprocess.check_output(
+                [script_path] + ['update_slice'] + imsi + apn_dict['apn' + var_index] + apn_dict['sst' + var_index] +
+                apn_dict['dl' + var_index] + unit + apn_dict['ul' + var_index]
+                + apn_dict['QoS' + var_index] + apn_dict['arp_priority' + var_index] + apn_dict[
+                    'arp_capability' + var_index] + apn_dict['arp_vulnerability' + var_index],
+                text=True, stderr=subprocess.STDOUT)
+
+    if isinstance(json_data, dict):
+        try:
+            num_profiles = json_data['count']
+            firstAPN = json_data['1']
+            for key, value in firstAPN.items():
+                if key == "imsi":
+                    imsi.append(str(value))
+                if key == "ki":
+                    ki.append(str(value))
+                if key == "opc":
+                    opc.append(str(value))
+                if key == "sst":
+                    sst.append(str(value))
+                if key == "apn":
+                    if value != "":
+                        apn.append(str(value))
+                if key == "ip":
+                    if value != "":
+                        ip[0] = (str(value))
+                if key == "dl":
+                    if value != " ":
+                        dl.append(str(value))
+                if key == "unit":
+                    if value != "":
+                        unit.append(str(value))
+                if key == "ul":
+                    if value != "":
+                        ul.append(str(value))
+                if key == "QoS":
+                    if value != "":
+                        qos.append(str(value))
+                if key == "arp_priority":
+                    if value != "":
+                        arp_priority.append(str(value))
+                if key == "arp_capability":
+                    if value != "":
+                        arp_capability.append(str(value))
+                if key == "arp_vulnerability":
+                    if value != "":
+                        arp_vulnerability.append(str(value))
+
+            print(imsi, ki, opc, sst, apn, dl, unit, ul, qos, arp_priority, arp_capability, arp_vulnerability)
+
+            output = subprocess.check_output([script_path] + ['add'] + imsi + ki + opc + sst + apn + dl + unit + ul
+                                             + qos + arp_priority + arp_capability + arp_vulnerability,
+                                             text=True, stderr=subprocess.STDOUT)
+            print(ujson.dumps(output))
+            # After creating the UE, then add the other apns, (if they exist)
+            for i in range(2, num_profiles + 1):
+                for key, value in json_data.items():
+                    if key == str(i):
+                        otherAPNS(value, str(i))
+        except:
+            pass

--- a/opncell/src/opnsense/scripts/opncore/opncore/setup.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+user=root
+group=wheel
+
+mkdir -p /var/run/epc
+chown -R $user:$group /var/run/epc
+chmod 777 /var/run/epc
+
+# logfile (if used)
+mkdir -p /var/log/opncore
+cp -r /usr/ports/open5gs/install/var/log/open5gs/.  /var/log/opncore/
+chown -R $user:$group /var/log/opncore

--- a/opncell/src/opnsense/scripts/opncore/opncore/showUsers.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/showUsers.py
@@ -1,0 +1,68 @@
+#!/usr/local/bin/python3
+
+import yaml
+import subprocess
+import ujson
+import sys
+import json
+import os
+
+
+def fetch_users():
+    os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+    os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+    os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+    os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+    os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+
+    script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+    bash_script = f'{script_path} showfiltered'
+    script_arguments = ['showfiltered']
+    i = ['3147000348934279']
+    # Use subprocess to run the Bash script
+    user_details = []
+    dets = {}
+
+    try:
+        output = subprocess.check_output([script_path] + script_arguments , text=True, stderr=subprocess.STDOUT)
+        #  Run the Bash script
+        output_list = output.strip().split('\n')
+
+        # Parse each JSON object separately
+        for json_str in output_list:
+            try:
+                data = json.loads(json_str)
+                imsi = data.get("imsi")
+                k = data.get("security", {}).get("k")
+                opc = data.get("security", {}).get("opc")
+
+                # Extract the "name" field from the "session" array if it exists
+               # session = data.get("slice", [{}])[0].get("session", [{}])
+                slice_array = data.get("slice", [])
+                names = []
+               # print(type(slice_array))
+                for slice_data in slice_array:
+                   # print(slice_array)
+                    session_array = slice_data.get("session", [])
+                    for session_data in session_array:
+                        name = session_data.get("name")
+                        names.append(name)
+                #names = [session_data.get("name") for session_data in session]
+                names_str = ",".join(names)
+                dets = {"imsi": imsi, "ki": k, "opc": opc, "apn": names_str}
+                user_details.append(dets)
+
+            except json.JSONDecodeError as e:
+               # print(f"Error parsing JSON: {e}")
+                pass
+        print(ujson.dumps(user_details))
+
+    except subprocess.CalledProcessError as e:
+        #print(f"Error running the Bash script: {e}")
+        #print(f"Command output: {e.output}")
+        pass
+
+    return user_details
+
+
+fetch_users()

--- a/opncell/src/opnsense/scripts/opncore/opncore/startMongo.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/startMongo.sh
@@ -1,0 +1,33 @@
+export PATH="/root/mongo/build/install/bin/:$PATH"
+export PATH="/root/mongo/build/install/bin/mongod:$PATH"
+
+
+checkMongo() {
+
+    command="ps aux | grep mongod | awk '\$8 == \"I+\" || \$8 == \"Is\" || \$8 == \"T\" {print \$8}'"
+    status=$(eval "$command")
+    if test "$status" == "T"; then
+       pid_command="ps aux | grep mongod | awk '\$8 == \"T\" {print \$2}'"
+       pid=$(eval "$pid_command")
+       kill -9 "$pid"
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+      cd "$directory_path" || exit 1
+      mongod --dbpath ./data/db &
+      echo "OK"
+  #sleep 1
+    fi
+
+   if test -z  "$status" ; then
+      mongo_binary_path=$(which mongod)
+      directory_path=$(dirname "$mongo_binary_path")
+      cd "$directory_path" || exit 1
+     
+      mkdir -p ./data/db
+      mongod --dbpath ./data/db &
+      echo "OK" 
+   #   sleep 1
+ fi
+}
+
+checkMongo

--- a/opncell/src/opnsense/scripts/opncore/opncore/startmmed.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/startmmed.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+command="$1"
+PIDFILE="$2"
+
+"${command}" -D > /dev/null 2>&1
+
+ps aux | grep ${command}  | awk '$8 == "Is" || $8 == "Ss" || $8 == "Rs" {print $2}' > ${PIDFILE} 
+
+

--- a/opncell/src/opnsense/scripts/opncore/opncore/stopMongo.sh
+++ b/opncell/src/opnsense/scripts/opncore/opncore/stopMongo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash 
+
+checkMongo() {
+
+    command="ps aux | grep mongod | awk '\$8 == \"I+\" || \$8 == \"Is\" || \$8 == \"T\" {print \$8}'"
+    status=$(eval "$command")
+    if test "$status" != "T"; then
+       pid_command="ps aux | grep mongod | awk '\$8 == \"I\" || \$8 == \"I+\" || \$8 == \"Is\" || \$8 == \"S\" {print \$2}'"
+       pid=$(eval "$pid_command")
+       kill -9 "$pid"
+    fi
+}
+
+checkMongo

--- a/opncell/src/opnsense/scripts/opncore/opncore/updateUser.py
+++ b/opncell/src/opnsense/scripts/opncore/opncore/updateUser.py
@@ -1,0 +1,81 @@
+#!/usr/local/bin/python3
+
+import subprocess
+import sys
+import json
+import os
+import ast
+
+os.environ['PATH'] = '/usr/local/opnsense/scripts/opncore/opncore_db.sh:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/bin/bash:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/:' + os.environ.get('PATH', '')
+os.environ['PATH'] = '/root/mongo/build/install/bin/mongod:' + os.environ.get('PATH', '')
+os.environ['PWD'] = '/usr/local/opnsense/scripts/opncore:' + os.environ.get('PWD', '')
+
+if len(sys.argv) > 0:
+    script_path = '/usr/local/opnsense/scripts/opncore/opncore_db.sh'
+    x = sys.argv[1]
+    y = x.replace('[', "")
+    t = y.replace(']', '')
+    json_data = json.loads(t)
+    # print(type(json_data))
+
+    imsi = []
+    ip = []
+    apn = []
+    arp_priority = []
+    dl = []
+    unit = ['2']
+    ul = []  # 2 is the unit for megabytes in mongodb
+    arp_capability = []
+    arp_vulnerability = []
+    qos = []
+    sst = []
+
+    if isinstance(json_data, dict):
+        # print(json_data)
+        try:
+            for key, value in json_data.items():
+                if key == "imsi":
+                    imsi.append(str(value))
+                    # print(imsi[0])
+                if key == "sst":
+                    sst.append(str(value))
+                if key == "apn":
+                    if value != "":
+                        apn.append(str(value))
+                if key == "ip":
+                    if value != "":
+                        ip[0] = (str(value))
+                if key == "dl":
+                    if value != " ":
+                        dl.append(str(value))
+                if key == "unit":
+                    if value != "":
+                        unit.append(str(value))
+                if key == "ul":
+                    if value != "":
+                        ul.append(str(value))
+                if key == "QoS":
+                    if value != "":
+                        qos.append(str(value))
+                if key == "arp_priority":
+                    if value != "":
+                        arp_priority.append(str(value))
+                if key == "arp_capability":
+                    if value != "":
+                        arp_capability.append(str(value))
+                if key == "arp_vulnerability":
+                    if value != "":
+                        arp_vulnerability.append(str(value))
+
+            # print(imsi, sst, apn, dl, unit, ul, qos, arp_priority, arp_capability, arp_vulnerability)
+            # print("here")
+            output = subprocess.check_output([script_path] + ['set_apn'] + imsi + apn + sst + dl + unit + ul
+                                             + qos + arp_priority + arp_capability + arp_vulnerability,
+                                             text=True, stderr=subprocess.STDOUT)
+
+        except:
+            pass
+else:
+    print("No args")

--- a/opncell/src/opnsense/scripts/opncore/opncore_db.sh.back
+++ b/opncell/src/opnsense/scripts/opncore/opncore_db.sh.back
@@ -136,11 +136,98 @@ if [ "$1" = "add" ]; then
         exit $?
     fi
 
-    if [ "$#" -eq 5 ]; then
+    if [ "$#" -eq 14 ]; then
         IMSI=$2
-        IP=$3
-        KI=$4
-        OPC=$5
+        KI=$3
+        OPC=$4
+        SST=$5
+        APN=$6
+        DL=$7
+        UNIT=$8
+        UL=$9
+        QOS=${10}
+        PRIORITY_LEVEL=${11}
+        ARP_CAPA=${12}
+        ARP_VUL=${13}
+        IP=${14}
+
+        mongo --eval "db.subscribers.insertOne(
+            {
+                \"_id\": new ObjectId(),
+                \"schema_version\": NumberInt(1),
+                \"imsi\": \"$IMSI\",
+                \"msisdn\": [],
+                \"imeisv\": [],
+                \"mme_host\": [],
+                \"mm_realm\": [],
+                \"purge_flag\": [],
+                \"slice\":[
+                {
+                    \"sst\": NumberInt($SST),
+                    \"default_indicator\": true,
+                    \"session\": [
+                    {
+                        \"name\" : \"$APN\",
+                        \"type\" : NumberInt(3),
+                        \"qos\" :
+                        { \"index\": NumberInt($QOS),
+                            \"arp\":
+                            {
+                                \"priority_level\" : NumberInt($PRIORITY_LEVEL),
+                                \"pre_emption_capability\": NumberInt($ARP_CAPA),
+                                \"pre_emption_vulnerability\": NumberInt($ARP_VUL)
+                            }
+                        },
+                        \"ambr\":
+                        {
+                            \"downlink\":
+                            {
+                                \"value\": NumberInt($DL),
+                                \"unit\": NumberInt($UNIT)
+                            },
+                            \"uplink\":
+                            {
+                                \"value\": NumberInt($UL),
+                                \"unit\": NumberInt($UNIT)
+                            }
+                        },
+                         \"ue\":
+                        {
+                            \"addr\": \"$IP\"
+                        },
+                        \"pcc_rule\": [],
+                        \"_id\": new ObjectId(),
+                    }],
+                    \"_id\": new ObjectId(),
+                }],
+                \"security\":
+                {
+                    \"k\" : \"$KI\",
+                    \"op\" : null,
+                    \"opc\" : \"$OPC\",
+                    \"amf\" : \"8000\",
+                },
+                \"ambr\" :
+                {
+                    \"downlink\" : { \"value\": NumberInt($DL), \"unit\": NumberInt($UNIT)},
+                    \"uplink\" : { \"value\": NumberInt($UL), \"unit\": NumberInt($UNIT)}
+                },
+                \"access_restriction_data\": 32,
+                \"network_access_mode\": 0,
+                \"subscriber_status\": 0,
+                \"operator_determined_barring\": 0,
+                \"subscribed_rau_tau_timer\": 12,
+                \"__v\": 0
+            }
+            );" $DB_URI
+        exit $?
+    fi
+
+    if [ "$#" -eq 4 ]; then
+        IMSI=$2
+
+        KI=$3
+        OPC=$4
 
         mongo --eval "db.subscribers.insertOne(
             {
@@ -158,7 +245,7 @@ if [ "$1" = "add" ]; then
                     \"default_indicator\": true,
                     \"session\": [
                     {
-                        \"name\" : \"internet\",
+                        \"name\" : \"teal\",
                         \"type\" : NumberInt(3),
                         \"qos\" :
                         { \"index\": NumberInt(9),
@@ -181,10 +268,6 @@ if [ "$1" = "add" ]; then
                                 \"value\": NumberInt(1000000000),
                                 \"unit\": NumberInt(0)
                             }
-                        },
-                        \"ue\":
-                        {
-                            \"addr\": \"$IP\"
                         },
                         \"pcc_rule\": [],
                         \"_id\": new ObjectId(),
@@ -499,7 +582,20 @@ if [ "$1" = "remove" ]; then
     fi
 
     IMSI=$2
-    mongo --eval "db.subscribers.deleteOne({\"imsi\": \"$IMSI\"});" $DB_URI
+    output=$(mongo --quiet --eval "db.subscribers.deleteOne({\"imsi\": \"$IMSI\"});" $DB_URI 2>/dev/null)
+    json_output=$(echo "$output" | awk '/{/,/}/')
+    deleted_count=$(echo "$json_output" | awk -F '[:,]' '{for(i=1;i<=NF;i++) if($i ~ /"deletedCount"/) print $(i+1)}')
+    #deleted_count=$(echo "$deleted_count" | tr -d '\n\r')
+    deleted_count=$(echo "$deleted_count" | awk '{$1=$1};1')
+    deleted_count=$(echo "$deleted_count" | cut -d' ' -f1)
+
+    deleted_count=$(echo "$deleted_count" | sed 's/0}$//')
+    #if [ -n "$deleted_count" ] && [ "$deleted_count" -gt 0 ]; then
+     #   echo "Document with IMSI $IMSI has been deleted."
+    #else
+     #   echo "No document with IMSI $IMSI found or deleted."
+    #fi
+    echo $deleted_count
     exit $?
 fi
 


### PR DESCRIPTION
Upon reboot, OPNsense's services module fails to locate the PIDs for the running services.
As a result, it incorrectly displays these services as "Not running," even though they are running.

The startup scripts have been modified to ensure that the service PIDs can be read by the services module on server reboot.